### PR TITLE
Replace errors with warnings

### DIFF
--- a/duet_tools/calibration.py
+++ b/duet_tools/calibration.py
@@ -331,7 +331,8 @@ def assign_targets_from_sb40(
         if np.max(fuel_arr) == np.min(fuel_arr):
             warnings.warn(
                 f"There is only one value for {fuel_type} {parameter}. "
-                "Setting calibration method to 'constant'"
+                "Setting calibration method to 'constant'",
+                UserWarning,
             )
             method = "constant"
             args = ["value"]
@@ -349,7 +350,8 @@ def assign_targets_from_sb40(
         if np.max(fuel_arr) == np.min(fuel_arr):
             warnings.warn(
                 f"There is only one value for {fuel_type} {parameter}. "
-                "Setting calibration method to 'constant'"
+                "Setting calibration method to 'constant'",
+                UserWarning,
             )
             method = "constant"
             args = ["value"]

--- a/duet_tools/calibration.py
+++ b/duet_tools/calibration.py
@@ -286,7 +286,7 @@ def assign_targets(method: str, **kwargs: float) -> Targets:
 
 def assign_targets_from_sb40(
     query: LandfireQuery, fuel_type: str, parameter: str, method: str = "maxmin"
-):
+) -> Targets:
     """
     Assign a calibration target and method for a given fuel type and parameter.
 
@@ -329,25 +329,39 @@ def assign_targets_from_sb40(
     fuel_arr = fuel_arr[np.where(fuel_arr > 0)]
     if method == "maxmin":
         if np.max(fuel_arr) == np.min(fuel_arr):
-            raise ValueError(
+            warnings.warn(
                 f"There is only one value for {fuel_type} {parameter}. "
-                "Please use 'constant' calibration method"
+                "Setting calibration method to 'constant'"
             )
+            method = "constant"
+            args = ["value"]
+            targets = [np.mean(fuel_arr)]
+        else:
+            method = "maxmin"
+            args = ["max", "min"]
+            targets = [np.max(fuel_arr), np.min(fuel_arr)]
         return Targets(
-            method="maxmin",
-            args=["max", "min"],
-            targets=[np.max(fuel_arr), np.min(fuel_arr)],
+            method=method,
+            args=args,
+            targets=targets,
         )
     if method == "meansd":
         if np.max(fuel_arr) == np.min(fuel_arr):
-            raise ValueError(
+            warnings.warn(
                 f"There is only one value for {fuel_type} {parameter}. "
-                "Please use 'constant' calibration method"
+                "Setting calibration method to 'constant'"
             )
+            method = "constant"
+            args = ["value"]
+            targets = [np.mean(fuel_arr)]
+        else:
+            method = "meansd"
+            args = ["mean", "sd"]
+            targets = [np.mean(fuel_arr), np.std(fuel_arr)]
         return Targets(
-            method="meansd",
-            args=["mean", "sd"],
-            targets=[np.mean(fuel_arr), np.std(fuel_arr)],
+            method=method,
+            args=args,
+            targets=targets,
         )
     if method == "constant":
         if np.max(fuel_arr) != np.min(fuel_arr):

--- a/tests/test_calibration_module.py
+++ b/tests/test_calibration_module.py
@@ -369,7 +369,7 @@ class TestLandfireTargets:
         assert grass_density.args == ["max", "min"]
         assert len(grass_density.targets) == 2
         # test fuel and parameter with only one value
-        with pytest.raises(ValueError):
+        with pytest.warns(UserWarning):
             grass_moisture = assign_targets_from_sb40(query, "grass", "moisture")
         grass_moisture = assign_targets_from_sb40(
             query, "grass", "moisture", method="constant"


### PR DESCRIPTION
assign_targets_from_sb40 will now give a warning when only one value for a given fuel type and parameter is present in the LANDFIRE data. The targets will be then be assigned with constant calibration.